### PR TITLE
Initialize persistent media permissions before deployment

### DIFF
--- a/deploy/server3/README.md
+++ b/deploy/server3/README.md
@@ -12,8 +12,9 @@ the internal `kira-database` network. The API, public site, and admin studio bin
 - `postgres-init.sh` creates separate migration and runtime roles on the first database initialization.
 - `nginx/*.conf` keeps the site and API virtual hosts independent from existing hosts.
 - `kira-deploy` accepts an exact-SHA image stream, verifies it, backs up PostgreSQL before
-  migrations, health-gates activation, and restores the prior component image after a failed
-  health check.
+  migrations, initializes the tutorial-media volume for the backend image's declared numeric
+  UID/GID, health-gates activation, and restores the prior component image after a failed health
+  check. The deployment fails closed if the volume is not writable by that runtime identity.
 - `kira-deploy-gateway` restricts the CI SSH account to
   `deploy backend|web|admin <40-character-sha>`.
 - `kira-deploy.sudoers` grants only the two root deploy commands. `kira-deploy.sshd.conf` forces every login for that account through the gateway and disables forwarding, TTYs, and password authentication.

--- a/deploy/server3/kira-deploy
+++ b/deploy/server3/kira-deploy
@@ -55,6 +55,31 @@ configured_image() {
   awk -F= -v key="$key" '$1 == key { print $2; exit }' "$images_file"
 }
 
+prepare_tutorial_media_volume() {
+  local image=$1
+  local image_user uid gid
+  image_user=$(docker image inspect --format '{{.Config.User}}' "$image")
+  [[ $image_user =~ ^([0-9]+):([0-9]+)$ ]] ||
+    fail "backend image must declare a numeric uid:gid"
+  uid=${BASH_REMATCH[1]}
+  gid=${BASH_REMATCH[2]}
+
+  docker volume create kira-tutorial-media >/dev/null
+  docker run --rm --network none --read-only \
+    --user 0:0 --entrypoint sh \
+    --volume kira-tutorial-media:/var/lib/kira/tutorial-media \
+    "$image" -ec \
+    'chown "$1:$2" "$3"; chmod 750 "$3"' \
+    sh "$uid" "$gid" /var/lib/kira/tutorial-media
+
+  docker run --rm --network none --read-only \
+    --user "$image_user" --entrypoint sh \
+    --volume kira-tutorial-media:/var/lib/kira/tutorial-media \
+    "$image" -ec \
+    'test -d "$1" && test -r "$1" && test -w "$1" && test -x "$1"' \
+    sh /var/lib/kira/tutorial-media
+}
+
 rollback_component() {
   local component=$1
   local image=$2
@@ -108,6 +133,7 @@ activate_backend() {
   [[ $image =~ ^kira-backend:[A-Za-z0-9_.-]+$ ]] || fail "invalid backend image"
   previous=$(configured_image KIRA_BACKEND_IMAGE)
   docker image inspect "$image" >/dev/null
+  prepare_tutorial_media_volume "$image"
   compose up --detach postgres
   wait_healthy kira-postgres 30
   backup_database

--- a/scripts/smoke/container-smoke.sh
+++ b/scripts/smoke/container-smoke.sh
@@ -11,6 +11,7 @@ suffix="$$"
 network="kira-release-smoke-$suffix"
 database="kira-release-smoke-postgres-$suffix"
 application="kira-release-smoke-app-$suffix"
+media_volume="kira-release-smoke-media-$suffix"
 smoke_temp_root=${KIRA_SMOKE_TEMP_ROOT:-"$PWD/build/tmp"}
 postgres_image="postgres:17.6-alpine@sha256:ef257d85f76e48da1c64832459b59fcaba1a4dac97bf5d7450c77753542eee94"
 failure_stage=initialization
@@ -31,6 +32,7 @@ redact_stream() {
 
 cleanup() {
   docker rm --force "$application" "$database" >/dev/null 2>&1 || true
+  docker volume rm --force "$media_volume" >/dev/null 2>&1 || true
   docker network rm "$network" >/dev/null 2>&1 || true
   find "$temporary_directory" -type f -exec chmod 600 {} \; 2>/dev/null || true
   rm -rf "$temporary_directory"
@@ -114,8 +116,31 @@ docker run --rm --network "$network" --entrypoint java \
   > "$temporary_directory/migration.log" 2>&1
 
 failure_stage="production application startup"
+image_user=$(docker image inspect --format '{{.Config.User}}' "$image")
+if [[ ! $image_user =~ ^([0-9]+):([0-9]+)$ ]]; then
+  echo "production image must declare a numeric uid:gid" >&2
+  exit 1
+fi
+image_uid=${BASH_REMATCH[1]}
+image_gid=${BASH_REMATCH[2]}
+docker volume create "$media_volume" >/dev/null
+docker run --rm --network none --read-only \
+  --user 0:0 --entrypoint sh \
+  --volume "$media_volume:/var/lib/kira/tutorial-media" \
+  "$image" -ec \
+  'chown "$1:$2" "$3"; chmod 750 "$3"' \
+  sh "$image_uid" "$image_gid" /var/lib/kira/tutorial-media
+docker run --rm --network none --read-only \
+  --user "$image_user" --entrypoint sh \
+  --volume "$media_volume:/var/lib/kira/tutorial-media" \
+  "$image" -ec \
+  'test -d "$1" && test -r "$1" && test -w "$1" && test -x "$1"' \
+  sh /var/lib/kira/tutorial-media
+
 docker run --detach --name "$application" --network "$network" \
+  --read-only --tmpfs /tmp:size=128m,mode=1777 \
   --volume "$temporary_directory/ca.crt:/run/kira-smoke/ca.crt:ro" \
+  --volume "$media_volume:/var/lib/kira/tutorial-media" \
   --env "SPRING_DATASOURCE_URL=$jdbc_url" --env SPRING_DATASOURCE_USERNAME=kira \
   --env "SPRING_DATASOURCE_PASSWORD=$database_password" --env "KIRA_JWT_SECRET=$jwt_secret" \
   --env KIRA_SECURITY_EXTERNAL_BASE_URL=https://api.smoke.invalid \
@@ -124,6 +149,7 @@ docker run --detach --name "$application" --network "$network" \
   --env KIRA_SIGNING_ACTIVE_KEY_ID=smoke --env "KIRA_SIGNING_PRIVATE_KEY=$signing_private" \
   --env KIRA_SIGNING_VERIFICATION_KEYS_0_KEY_ID=smoke \
   --env "KIRA_SIGNING_VERIFICATION_KEYS_0_PUBLIC_KEY=$signing_public" \
+  --env KIRA_TUTORIAL_MEDIA_DIRECTORY=/var/lib/kira/tutorial-media \
   "$image" >/dev/null
 
 failure_stage="readiness, liveness, and metrics probes"


### PR DESCRIPTION
## Root cause
The first deployment after adding the named tutorial-media volume created its root as root-owned mode 0755. The backend image runs as numeric user 10001:10001, so both the candidate and rollback image failed during tutorial seeding with an access-denied exception. The deployment health gate correctly restored the prior image; production recovered after correcting only the empty volume root ownership.

## Fix
- derive the backend image's declared numeric UID/GID and initialize the named volume before migrations and activation
- fail closed unless that runtime identity can read, write, and traverse the volume
- extend the production smoke test to reproduce a root-owned named volume and a read-only runtime container
- document the volume gate

## Verification
- production rollback image is healthy
- persistent-volume/read-only regression smoke passed locally
- shell syntax and diff checks passed
- full backend check passed
- failed deployment: https://github.com/kira-manga/Kira-backend/actions/runs/30085649172